### PR TITLE
Implement SQL server discovery comboboxes

### DIFF
--- a/WMS - Projekt/DataAccess/SqlServerSearch.cs
+++ b/WMS - Projekt/DataAccess/SqlServerSearch.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Sql;
+
+namespace WMS___Projekt.DataAccess
+{
+    public static class SqlServerSearch
+    {
+        public static List<string> GetAvailableServers()
+        {
+            List<string> servers = new List<string>();
+            try
+            {
+                DataTable dt = SqlDataSourceEnumerator.Instance.GetDataSources();
+                foreach (DataRow row in dt.Rows)
+                {
+                    string server = row["ServerName"].ToString();
+                    string instance = row["InstanceName"].ToString();
+                    if (!string.IsNullOrEmpty(instance))
+                    {
+                        servers.Add($"{server}\\{instance}");
+                    }
+                    else
+                    {
+                        servers.Add(server);
+                    }
+                }
+            }
+            catch
+            {
+                // Enumeration can fail depending on environment.
+            }
+            return servers;
+        }
+    }
+}

--- a/WMS - Projekt/Forms/LoginForm.Designer.cs
+++ b/WMS - Projekt/Forms/LoginForm.Designer.cs
@@ -37,7 +37,7 @@ namespace WMS___Projekt.Forms
             passwordTextbox = new TextBox();
             isWindowsAuthenticationCheckbox = new CheckBox();
             serverNameLabel = new Label();
-            serverNameTextbox = new TextBox();
+            serverNameComboBox = new ComboBox();
             databaseNameLabel = new Label();
             databaseNameTextbox = new TextBox();
             newDatabaseLabel = new Label();
@@ -118,12 +118,14 @@ namespace WMS___Projekt.Forms
             serverNameLabel.TabIndex = 7;
             serverNameLabel.Text = "Server name";
             // 
-            // serverNameTextbox
-            // 
-            serverNameTextbox.Location = new Point(190, 38);
-            serverNameTextbox.Name = "serverNameTextbox";
-            serverNameTextbox.Size = new Size(248, 23);
-            serverNameTextbox.TabIndex = 8;
+            // serverNameComboBox
+            //
+            serverNameComboBox.FormattingEnabled = true;
+            serverNameComboBox.Location = new Point(190, 38);
+            serverNameComboBox.Name = "serverNameComboBox";
+            serverNameComboBox.Size = new Size(248, 23);
+            serverNameComboBox.TabIndex = 8;
+            serverNameComboBox.DropDown += serverNameComboBox_DropDown;
             // 
             // databaseNameLabel
             // 
@@ -168,7 +170,7 @@ namespace WMS___Projekt.Forms
             Controls.Add(newDatabaseLabel);
             Controls.Add(databaseNameTextbox);
             Controls.Add(databaseNameLabel);
-            Controls.Add(serverNameTextbox);
+            Controls.Add(serverNameComboBox);
             Controls.Add(serverNameLabel);
             Controls.Add(isWindowsAuthenticationCheckbox);
             Controls.Add(passwordTextbox);
@@ -188,5 +190,6 @@ namespace WMS___Projekt.Forms
 
 
         private Button createNewDatabaseButton;
+        private ComboBox serverNameComboBox;
     }
 }

--- a/WMS - Projekt/Forms/LoginForm.cs
+++ b/WMS - Projekt/Forms/LoginForm.cs
@@ -18,7 +18,7 @@ namespace WMS___Projekt.Forms
         private TextBox loginTextbox;
         private CheckBox isWindowsAuthenticationCheckbox;
         private Label serverNameLabel;
-        private TextBox serverNameTextbox;
+        private ComboBox serverNameComboBox;
         private Label databaseNameLabel;
         private TextBox databaseNameTextbox;
         private TextBox passwordTextbox;
@@ -46,7 +46,7 @@ namespace WMS___Projekt.Forms
         {
             string login = loginTextbox.Text;
             string password = passwordTextbox.Text;
-            string serverName = serverNameTextbox.Text;
+            string serverName = serverNameComboBox.Text;
             string databaseName = databaseNameTextbox.Text;
             bool isWindowsAuthentication = isWindowsAuthenticationCheckbox.Checked;
 
@@ -80,6 +80,18 @@ namespace WMS___Projekt.Forms
         private void TextBox2_TextChanged(object sender, EventArgs e)
         {
 
+        }
+
+        private void serverNameComboBox_DropDown(object sender, EventArgs e)
+        {
+            if (serverNameComboBox.Items.Count == 0)
+            {
+                var servers = SqlServerSearch.GetAvailableServers();
+                foreach (var s in servers)
+                {
+                    serverNameComboBox.Items.Add(s);
+                }
+            }
         }
 
         private void Label2_Click(object sender, EventArgs e)

--- a/WMS - Projekt/Forms/NewDatabaseForm.Designer.cs
+++ b/WMS - Projekt/Forms/NewDatabaseForm.Designer.cs
@@ -28,7 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-            serverNameTextBox = new TextBox();
+            serverNameComboBox = new ComboBox();
             newDatabaseTextbox = new TextBox();
             serverNameLabel = new Label();
             newDatabaseNameLabel = new Label();
@@ -41,13 +41,14 @@
             isWindowsAuthenticationCheckbox = new CheckBox();
             SuspendLayout();
             // 
-            // serverNameTextBox
-            // 
-            serverNameTextBox.Location = new Point(202, 41);
-            serverNameTextBox.Name = "serverNameTextBox";
-            serverNameTextBox.Size = new Size(251, 23);
-            serverNameTextBox.TabIndex = 0;
-            serverNameTextBox.TextChanged += ServerNameTextBox_TextChanged;
+            // serverNameComboBox
+            //
+            serverNameComboBox.FormattingEnabled = true;
+            serverNameComboBox.Location = new Point(202, 41);
+            serverNameComboBox.Name = "serverNameComboBox";
+            serverNameComboBox.Size = new Size(251, 23);
+            serverNameComboBox.TabIndex = 0;
+            serverNameComboBox.DropDown += serverNameComboBox_DropDown;
             // 
             // newDatabaseTextbox
             // 
@@ -139,6 +140,7 @@
             isWindowsAuthenticationCheckbox.TabIndex = 10;
             isWindowsAuthenticationCheckbox.Text = "Authenticate with Windows Login";
             isWindowsAuthenticationCheckbox.UseVisualStyleBackColor = true;
+            isWindowsAuthenticationCheckbox.CheckedChanged += isWindowsAuthenticationCheckbox_CheckedChanged;
             // 
             // NewDatabaseForm
             // 
@@ -155,7 +157,7 @@
             Controls.Add(newDatabaseNameLabel);
             Controls.Add(serverNameLabel);
             Controls.Add(newDatabaseTextbox);
-            Controls.Add(serverNameTextBox);
+            Controls.Add(serverNameComboBox);
             FormBorderStyle = FormBorderStyle.FixedSingle;
             Name = "NewDatabaseForm";
             Text = "Create new database";
@@ -175,7 +177,7 @@
 
         #endregion
 
-        private TextBox serverNameTextBox;
+        private ComboBox serverNameComboBox;
         private TextBox newDatabaseTextbox;
         private Label serverNameLabel;
         private Label newDatabaseNameLabel;

--- a/WMS - Projekt/Forms/NewDatabaseForm.cs
+++ b/WMS - Projekt/Forms/NewDatabaseForm.cs
@@ -24,7 +24,7 @@ namespace WMS___Projekt.Forms
         }
         private void CreateButton_Click(object sender, EventArgs e)
         {
-            string serverName = serverNameTextBox.Text;
+            string serverName = serverNameComboBox.Text;
             string databaseName = newDatabaseTextbox.Text;
             string login = serverLoginTextbox.Text;
             string password = serverPasswordTextbox.Text;
@@ -72,6 +72,18 @@ namespace WMS___Projekt.Forms
         private void cancelButton_Click_1(object sender, EventArgs e)
         {
             this.Close();
+        }
+
+        private void serverNameComboBox_DropDown(object sender, EventArgs e)
+        {
+            if (serverNameComboBox.Items.Count == 0)
+            {
+                var servers = SqlServerSearch.GetAvailableServers();
+                foreach (var s in servers)
+                {
+                    serverNameComboBox.Items.Add(s);
+                }
+            }
         }
     }
 }

--- a/WMSProjekt_Tests/Forms_Tests/LoginForm_Tests.cs
+++ b/WMSProjekt_Tests/Forms_Tests/LoginForm_Tests.cs
@@ -21,7 +21,7 @@ namespace WMS___Projekt.Tests
             bool isWindowsAuth = false;
 
             // Access private fields using reflection
-            PropertyInfo serverNameTextboxProperty = loginForm.GetType().GetProperty("serverNameTextbox", BindingFlags.NonPublic | BindingFlags.Instance);
+            PropertyInfo serverNameComboBoxProperty = loginForm.GetType().GetProperty("serverNameComboBox", BindingFlags.NonPublic | BindingFlags.Instance);
             PropertyInfo databaseNameTextboxProperty = loginForm.GetType().GetProperty("databaseNameTextbox", BindingFlags.NonPublic | BindingFlags.Instance);
             PropertyInfo loginTextboxProperty = loginForm.GetType().GetProperty("loginTextbox", BindingFlags.NonPublic | BindingFlags.Instance);
             PropertyInfo passwordTextboxProperty = loginForm.GetType().GetProperty("passwordTextbox", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -29,7 +29,7 @@ namespace WMS___Projekt.Tests
             MethodInfo loginButtonClickMethod = loginForm.GetType().GetMethod("loginButton_Click", BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Set private fields
-            ((TextBox)serverNameTextboxProperty.GetValue(loginForm)).Text = validServerName;
+            ((ComboBox)serverNameComboBoxProperty.GetValue(loginForm)).Text = validServerName;
             ((TextBox)databaseNameTextboxProperty.GetValue(loginForm)).Text = validDatabaseName;
             ((TextBox)loginTextboxProperty.GetValue(loginForm)).Text = validLogin;
             ((TextBox)passwordTextboxProperty.GetValue(loginForm)).Text = validPassword;


### PR DESCRIPTION
## Summary
- add `SqlServerSearch` helper for enumerating local SQL servers
- switch server name fields to ComboBoxes on Login and New Database forms
- populate server list on dropdown
- disable login fields when using Windows authentication on new DB form
- update unit tests for new combobox

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68628178c0fc8330a7c40304ba7ed5ff